### PR TITLE
backend: Added "endpoint" support to linspace

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -358,11 +358,11 @@ def trace(x):
     return _torch.einsum("...ii", x)
 
 
-def linspace(start, stop, num=50, dtype=None):
+def linspace(start, stop, num=50, endpoint=True, dtype=None):
     start_is_array = _torch.is_tensor(start)
     stop_is_array = _torch.is_tensor(stop)
 
-    if not (start_is_array or stop_is_array):
+    if not (start_is_array or stop_is_array) and endpoint:
         return _torch.linspace(start=start, end=stop, steps=num, dtype=dtype)
 
     if not start_is_array:
@@ -374,15 +374,22 @@ def linspace(start, stop, num=50, dtype=None):
     start = _torch.flatten(start)
     stop = _torch.flatten(stop)
 
-    return _torch.reshape(
-        _torch.vstack(
+    if endpoint:
+        result = _torch.vstack(
             [
                 _torch.linspace(start=start[i], end=stop[i], steps=num, dtype=dtype)
                 for i in range(start.shape[0])
             ]
-        ).T,
-        result_shape,
-    )
+        ).T
+    else:
+        result = _torch.vstack(
+            [
+                _torch.arange(start=start[i], end=stop[i], step=(stop[i]-start[i])/num, dtype=dtype)
+                for i in range(start.shape[0])
+            ]
+        ).T
+
+    return _torch.reshape(result, result_shape)
 
 
 def equal(a, b, **kwargs):


### PR DESCRIPTION
Hi. I just saw my other change got mainlined so I was looking into other changes. However, since the policy is apparently only commands that are used in geomstats should be supported on the backend (which I can obviously understand), there are not so many other changes from my side. One additional thing I have is the support for endpoint=False in linspace. If you think that is any useful to you, feel free to merge.
Sidenote: I did not treat the "not (start_is_array or stop_is_array) " case differently. I think you are trying to see if these are scalar numbers - however, this case is also used when one inputs a list. For numpy, this works just fine, for pytorch, it doesn't. To make it work regardless, I just treated it as the (potentially) vector-valued case.

Considering some test cases fail anyway, I am not sure if I should run all tests for this PR.